### PR TITLE
Add video export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # ASCII_video_transform
 
 Webcam ASCII Video creator
+
+## Exporting ASCII video
+
+Use the **Start Recording** button to begin capturing the canvas. Once you are
+ready to finish, press **Stop Recording** and a `ascii_video.webm` file will be
+downloaded containing the recording of the ASCII render, including audio from
+the source video.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
   </head>
   <body>
     <main>
+      <button id="startRec">Start Recording</button>
+      <button id="stopRec" disabled>Stop Recording</button>
     </main>
     <script src="sketch.js"></script>
   </body>

--- a/sketch.js
+++ b/sketch.js
@@ -8,19 +8,30 @@ https://www.pattvira.com/
 ----------------------------------------
 */
 
-let asciiChar = "◼︎♦︎$@B%8&WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/\\|()1{}[]?-_+~<>i!lI;:,^`'. ";
-// let asciiChar = " .:-=+*#%@";
+const asciiChar =
+  "◼︎♦︎$@B%8&WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/\\|()1{}[]?-_+~<>i!lI;:,^`'. ";
+// const asciiChar = " .:-=+*#%@";
 
 let video;
-let size = 4;
-let vidSize;
+const size = 4;
+
+let recorder;
+let recordedChunks = [];
+let isRecording = false;
+let recordBtn;
+let stopBtn;
+let canvas;
 
 function setup() {
-  let canvas = createCanvas(720, 1280);
+  canvas = createCanvas(720, 1280);
   canvas.elt.getContext('2d', { willReadFrequently: true });
   textFont('Courier New'); // Fuente monotipo tipo ASCII
 
-  vidSize = width / size;
+
+  recordBtn = select('#startRec');
+  stopBtn = select('#stopRec');
+  recordBtn.mousePressed(startRecording);
+  stopBtn.mousePressed(stopRecording);
 
   video = createVideo("Automatic.MP4", videoLoaded);
   video.size(width / size, height / size);
@@ -61,4 +72,44 @@ function draw() {
       text(t, x, y);
     }
   }
+}
+
+function startRecording() {
+  if (isRecording) return;
+  recordedChunks = [];
+  const stream = canvas.elt.captureStream(30);
+  // Add audio from the video element if available
+  const audioTracks = video.elt.captureStream().getAudioTracks();
+  if (audioTracks.length > 0) {
+    stream.addTrack(audioTracks[0]);
+  }
+  recorder = new MediaRecorder(stream, { mimeType: 'video/webm' });
+  recorder.ondataavailable = (e) => {
+    if (e.data && e.data.size > 0) {
+      recordedChunks.push(e.data);
+    }
+  };
+  recorder.onstop = saveRecording;
+  recorder.start();
+  isRecording = true;
+  recordBtn.attribute('disabled', '');
+  stopBtn.removeAttribute('disabled');
+}
+
+function stopRecording() {
+  if (!isRecording) return;
+  recorder.stop();
+  isRecording = false;
+  recordBtn.removeAttribute('disabled');
+  stopBtn.attribute('disabled', '');
+}
+
+function saveRecording() {
+  const blob = new Blob(recordedChunks, { type: 'video/webm' });
+  const url = URL.createObjectURL(blob);
+  const a = createA(url, 'ascii_video.webm');
+  a.download = 'ascii_video.webm';
+  a.elt.click();
+  a.remove();
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## Summary
- add recording controls to UI
- implement MediaRecorder-based export
- document how to export
- capture source audio when recording

## Testing
- `node -v`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6856526855ac832ab87cb09c694714c9