### PR TITLE
Add IndexedDB cache for recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Use the **Start Recording** button to begin capturing the canvas. Once you are
 ready to finish, press **Stop Recording** and a `ascii_video.webm` file will be
 downloaded containing the recording of the ASCII render, including audio from
 the webcam if permission is granted.
+
+## Video cache
+
+After recording, the resulting video is also stored in the browser's
+`IndexedDB` database (`asciiVideoCache`). This cache can hold the latest
+recording so it can be retrieved later even if the page is reloaded.

--- a/sketch.js
+++ b/sketch.js
@@ -23,6 +23,10 @@ let recordBtn;
 let stopBtn;
 let canvas;
 
+// IndexedDB constants for caching recorded videos
+const DB_NAME = 'asciiVideoCache';
+const STORE_NAME = 'videos';
+
 function setup() {
   // create a temporary canvas; final size is set when the camera loads
   canvas = createCanvas(outputWidth, outputWidth);
@@ -119,4 +123,35 @@ function saveRecording() {
   a.elt.click();
   a.remove();
   URL.revokeObjectURL(url);
+
+  // store the recorded video in IndexedDB for caching
+  saveToCache('lastRecording', blob);
+}
+
+// Open an IndexedDB connection for caching videos
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// Save a blob in the cache
+async function saveToCache(key, blob) {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(blob, key);
+    tx.oncomplete = () => db.close();
+    tx.onerror = () => console.error('Cache save failed', tx.error);
+  } catch (err) {
+    console.error('IndexedDB error', err);
+  }
 }


### PR DESCRIPTION
## Summary
- cache the last recording in IndexedDB
- document new caching behavior in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857c6fed7a0832abefc40eb12ff426a